### PR TITLE
Fix bug where cmd_check_xdr is called with None

### DIFF
--- a/bot/routers/send.py
+++ b/bot/routers/send.py
@@ -1008,14 +1008,15 @@ async def handle_docs_photo(
                     return_url=result.return_url,
                 )
 
-                # Process XDR
-                await cmd_check_xdr(
-                    session=session,
-                    check_xdr=result.xdr,
-                    user_id=message.from_user.id,
-                    state=state,
-                    app_context=app_context,
-                )
+                # Process XDR if present
+                if result.xdr:
+                    await cmd_check_xdr(
+                        session=session,
+                        check_xdr=result.xdr,
+                        user_id=message.from_user.id,
+                        state=state,
+                        app_context=app_context,
+                    )
 
             elif qr_data.startswith("wc:"):
                 await handle_wc_uri(

--- a/bot/routers/sign.py
+++ b/bot/routers/sign.py
@@ -595,6 +595,9 @@ async def cmd_check_xdr(
     *,
     app_context: AppContext,
 ):
+    if check_xdr is None:
+        logger.error(f"cmd_check_xdr: check_xdr is None for user {user_id}")
+        return
     try:
         data = await state.get_data()
         part_xdr = data.get("part_xdr", "")

--- a/bot/routers/uri.py
+++ b/bot/routers/uri.py
@@ -55,14 +55,15 @@ async def process_remote_uri(session: AsyncSession, chat_id: int, uri_id: str, s
             return_url=result.return_url
         )
 
-        # Process XDR
-        await cmd_check_xdr(
-            session=session,
-            check_xdr=result.xdr,
-            user_id=chat_id,
-            state=state,
-            app_context=app_context
-        )
+        # Process XDR if present
+        if result.xdr:
+            await cmd_check_xdr(
+                session=session,
+                check_xdr=result.xdr,
+                user_id=chat_id,
+                state=state,
+                app_context=app_context
+            )
     except Exception as e:
         logger.error(f"process_remote_uri exception: {e}")
         await send_message(
@@ -116,14 +117,15 @@ async def process_stellar_uri(message: types.Message, state: FSMContext, session
             return_url=result.return_url
         )
 
-        # Process XDR
-        await cmd_check_xdr(
-            session=session,
-            check_xdr=result.xdr,
-            user_id=message.from_user.id,
-            state=state,
-            app_context=app_context
-        )
+        # Process XDR if present
+        if result.xdr:
+            await cmd_check_xdr(
+                session=session,
+                check_xdr=result.xdr,
+                user_id=message.from_user.id,
+                state=state,
+                app_context=app_context
+            )
     except Exception as e:
         logger.error(f"process_stellar_uri exception: {e}")
         await send_message(


### PR DESCRIPTION
The fix implements defensive checks to ensure that the `cmd_check_xdr` function is never called with a `None` value for the `check_xdr` argument.

Changes:
1.  **`bot/routers/uri.py`**: Added `if result.xdr:` checks in `process_remote_uri` and `process_stellar_uri` before invoking `cmd_check_xdr`.
2.  **`bot/routers/send.py`**: Added `if result.xdr:` check in `handle_docs_photo` before invoking `cmd_check_xdr`.
3.  **`bot/routers/sign.py`**: Modified `cmd_check_xdr` to return early with an error log if `check_xdr` is `None`.

These changes prevent `TypeError: object of type 'NoneType' has no len()` within `cmd_check_xdr`.

---
*PR created automatically by Jules for task [4884440333539275971](https://jules.google.com/task/4884440333539275971) started by @attid*