### PR TITLE
🔒 Fix insufficient entropy for transaction IDs

### DIFF
--- a/bot/tests/routers/test_sign.py
+++ b/bot/tests/routers/test_sign.py
@@ -260,7 +260,7 @@ async def test_cancel_biometric_sign(mock_telegram, router_app_context, setup_si
     dp.include_router(sign_router)
 
     user_id = 123
-    tx_id = f"{user_id}_test1234"
+    tx_id = f"{user_id}_0123456789abcdef0123"
     bot = router_app_context.bot
 
     # Setup fakeredis with the TX already stored
@@ -297,7 +297,7 @@ async def test_cancel_biometric_sign_expired_tx(mock_telegram, router_app_contex
     dp.include_router(sign_router)
 
     user_id = 123
-    tx_id = f"{user_id}_expired123"
+    tx_id = f"{user_id}_fedcba9876543210fedc"
     bot = router_app_context.bot
 
     # Setup fakeredis WITHOUT the TX (simulating expired)

--- a/bot/tests/test_signing_flow.py
+++ b/bot/tests/test_signing_flow.py
@@ -140,9 +140,9 @@ class TestPublishPendingTx:
             redis_client=fake_redis,
         )
 
-        # Check tx_id format
+        # Check tx_id format (user_id_ + 20 hex chars)
         assert tx_id.startswith("123_")
-        assert len(tx_id) == 12  # "123_" + 8 chars
+        assert len(tx_id) == 3 + 1 + 20  # 24 chars
 
         await fake_redis.aclose()
 


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Increased the entropy of transaction IDs (`tx_id`) generated in `bot/other/faststream_tools.py`.

### ⚠️ Risk: The potential impact if left unfixed
Previously, transaction IDs only had 32 bits of entropy (8 hex characters). Since these IDs are exposed via public URLs for the WebApp signing flow, an attacker could potentially guess valid transaction IDs and access or interfere with pending transactions.

### 🛡️ Solution: How the fix addresses the vulnerability
The random part of the `tx_id` now uses `secrets.token_hex(10)`, which provides 80 bits of entropy (20 hex characters). This makes brute-force guessing attacks practically impossible. 

The length was carefully balanced to remain compatible with Telegram's 64-byte `callback_data` limit. With a 20-character random part and a maximum 64-bit integer `user_id` (19-20 digits), the callback data strings (like `cancel_biometric_sign:{user_id}_{random}`) will remain under 64 bytes.

Existing tests were updated to reflect the new ID length.

---
*PR created automatically by Jules for task [14346526281968601923](https://jules.google.com/task/14346526281968601923) started by @attid*